### PR TITLE
Fix mobile queue button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # sports-ranked-queue
-System to queue up to ranked matches for sports
+
+Sistema simples de filas para partidas de esportes. Suporta futebol, basquete e vôlei.
+Grupos podem entrar na fila em modo normal ou ranked. No modo ranked os grupos
+precisam ter MMR parecido para a partida ser formada.
+
+## Como usar
+
+```bash
+python sports_queue.py
+```
+
+O exemplo no final do arquivo `sports_queue.py` demonstra a criação de alguns
+jogadores e grupos para o esporte **futebol** e como a fila forma uma partida
+quando há jogadores suficientes com MMR semelhante.
+```
+
+## Rodando o servidor
+
+Para executar o sistema como um servidor HTTP simples:
+
+```bash
+python server.py
+```
+
+Por padrao ele escuta na porta 8000 e oferece dois endpoints:
+`/add_group` para adicionar grupos e `/match` para tentar formar uma partida.
+
+## Aplicativo mobile
+
+O diretório `mobile/` possui um exemplo de aplicativo React Native que funciona
+tanto no Android quanto no iOS. O fluxo começa em uma **tela de login**,
+depois permite escolher entre **Ranked** ou **Normal Game** e só então mostra
+os botões para gerenciar o grupo. Use **Chamar amigo** para adicionar um
+jogador real e **Adicionar dummy** para incluir um amigo sem conta. Depois
+pressione **Buscar partida** para adicionar o grupo à fila e tentar formar uma
+partida automaticamente.
+
+Para rodar o app com o Expo:
+
+```bash
+cd mobile
+npm install
+npx expo start
+```
+
+Lembre-se de iniciar o `server.py` antes de abrir o aplicativo.
+
+## Testes
+
+Execute os testes com:
+
+```bash
+python -m unittest discover
+```

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,98 @@
+import React, {useState} from 'react';
+import {StyleSheet, View, Button, Text, TextInput} from 'react-native';
+
+export default function App() {
+  const [screen, setScreen] = useState('login');
+  const [username, setUsername] = useState('');
+  const [ranked, setRanked] = useState(true);
+  const [match, setMatch] = useState(null);
+  const [players, setPlayers] = useState([
+    {id: 'p1', mmr: 1000},
+    {id: 'p2', mmr: 1000}
+  ]);
+  const [dummyCount, setDummyCount] = useState(0);
+
+  function login() {
+    setScreen('mode');
+  }
+
+  function chooseMode(isRanked) {
+    setRanked(isRanked);
+    setScreen('queue');
+  }
+
+  function addFriend() {
+    const next = players.filter(p => !p.is_dummy).length + 1;
+    setPlayers([...players, {id: `p${next}`, mmr: 1000}]);
+  }
+
+  function addDummy() {
+    const next = dummyCount + 1;
+    setDummyCount(next);
+    setPlayers([...players, {id: `dummy${next}`, mmr: 1000, is_dummy: true}]);
+  }
+
+  async function findMatch() {
+    await fetch('http://localhost:8000/add_group', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({sport: 'futebol', players})
+    });
+
+    const resp = await fetch('http://localhost:8000/match', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({sport: 'futebol', ranked})
+    });
+    const data = await resp.json();
+    setMatch(data.match);
+  }
+
+  if (screen === 'login') {
+    return (
+      <View style={styles.container}>
+        <TextInput
+          style={styles.input}
+          placeholder="Usuário"
+          value={username}
+          onChangeText={setUsername}
+        />
+        <Button title="Entrar" onPress={login} />
+      </View>
+    );
+  }
+
+  if (screen === 'mode') {
+    return (
+      <View style={styles.container}>
+        <Button title="Ranked" onPress={() => chooseMode(true)} />
+        <Button title="Normal Game" onPress={() => chooseMode(false)} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Button title="Chamar amigo" onPress={addFriend} />
+      <Button title="Adicionar dummy" onPress={addDummy} />
+      <Text>Grupo com {players.length} jogadores</Text>
+      <Button title="Buscar partida" onPress={findMatch} />
+      {match && <Text>A partida possui {match.length} grupos.</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    width: '80%',
+    marginBottom: 12
+  }
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,18 @@
+# Mobile App
+
+Este diretório contém um exemplo simples de aplicativo React Native que consome a API do servidor Python.
+
+## Requisitos
+
+- Node.js e npm (ou yarn)
+- Expo CLI (`npm install -g expo-cli`)
+
+## Rodando
+
+```bash
+cd mobile
+npm install
+npx expo start
+```
+
+O aplicativo fará requisições para `http://localhost:8000` por padrão, portanto inicie `server.py` antes de rodá-lo. Ele começa em uma **tela de login**, em seguida apresenta a escolha entre **Ranked** ou **Normal Game**. A terceira tela contém os botões **Chamar amigo**, **Adicionar dummy** e **Buscar partida**. Esse último adiciona o grupo à fila e busca a partida de uma só vez.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sports-queue-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.5"
+  }
+}

--- a/server.py
+++ b/server.py
@@ -1,0 +1,80 @@
+"""Simple HTTP server exposing the queue manager API."""
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from sports_queue import Player, Group, QueueManager
+
+queue_manager = QueueManager()
+
+class RequestHandler(BaseHTTPRequestHandler):
+    """Handle API requests for adding groups and matching."""
+    def _send_json(self, data: dict, status: int = 200) -> None:
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get('Content-Length', 0))
+        raw = self.rfile.read(length)
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            self._send_json({'error': 'invalid json'}, status=400)
+            return
+
+        if self.path == '/add_group':
+            try:
+                sport = payload['sport']
+                players = [
+                    Player(p['id'], p.get('mmr', 1000), p.get('is_dummy', False))
+                    for p in payload['players']
+                ]
+            except (KeyError, TypeError):
+                self._send_json({'error': 'invalid payload'}, status=400)
+                return
+            queue_manager.add_group(sport, Group(players))
+            self._send_json({'status': 'ok'})
+        elif self.path == '/match':
+            try:
+                sport = payload['sport']
+            except KeyError:
+                self._send_json({'error': 'invalid payload'}, status=400)
+                return
+            ranked = payload.get('ranked', True)
+            match = queue_manager.match_groups(sport, ranked=ranked)
+            if match:
+                resp = {
+                    'match': [
+                        [
+                            {
+                                'id': p.player_id,
+                                'mmr': p.mmr,
+                                'is_dummy': p.is_dummy,
+                            }
+                            for p in g.players
+                        ]
+                        for g in match
+                    ]
+                }
+            else:
+                resp = {'match': None}
+            self._send_json(resp)
+        else:
+            self._send_json({'error': 'not found'}, status=404)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return  # silence logging
+
+def create_server(host: str = 'localhost', port: int = 8000) -> HTTPServer:
+    """Create an HTTP server instance bound to ``host`` and ``port``."""
+    return HTTPServer((host, port), RequestHandler)
+
+def run(host: str = 'localhost', port: int = 8000) -> None:
+    """Run the HTTP API server indefinitely."""
+    server = create_server(host, port)
+    print(f'Server running at http://{host}:{server.server_port}')
+    server.serve_forever()
+
+if __name__ == '__main__':
+    run()

--- a/sports_queue.py
+++ b/sports_queue.py
@@ -1,0 +1,118 @@
+"""Queue management for sports matches."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+DEFAULT_MMR = 1000
+
+
+@dataclass
+class Player:
+    """Represents a single player."""
+
+    player_id: str
+    mmr: int = DEFAULT_MMR
+    is_dummy: bool = False
+
+
+@dataclass
+class Group:
+    """Represents a group of players joining the queue together."""
+
+    players: List[Player] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.players = list(self.players)
+
+    @property
+    def size(self) -> int:
+        return len(self.players)
+
+    @property
+    def avg_mmr(self) -> float:
+        if not self.players:
+            return 0
+        return sum(p.mmr for p in self.players) / self.size
+
+    def __repr__(self) -> str:
+        return f"Group(size={self.size}, avg_mmr={self.avg_mmr:.1f})"
+
+
+class QueueManager:
+    SPORT_SLOTS = {
+        'futebol': 10,     # 5v5
+        'basquete': 10,    # 5v5
+        'volei': 12        # 6v6
+    }
+
+    def __init__(self) -> None:
+        """Initialize empty queues for each sport."""
+        self.queues: dict[str, List[Group]] = {
+            sport: [] for sport in self.SPORT_SLOTS
+        }
+
+    def add_group(self, sport: str, group: Group) -> None:
+        """Add a group to the queue for the given sport."""
+        if sport not in self.SPORT_SLOTS:
+            raise ValueError(f"Sport '{sport}' not supported")
+        self.queues[sport].append(group)
+
+    def match_groups(
+        self, sport: str, ranked: bool = True, mmr_threshold: int = 100
+    ) -> Optional[List[Group]]:
+        """Try to form a match for the given sport.
+
+        If ``ranked`` is ``True`` the groups' average MMR must be within
+        ``mmr_threshold`` of each other. Returns a list of groups if enough
+        players are found, otherwise ``None``.
+        """
+        if sport not in self.SPORT_SLOTS:
+            raise ValueError(f"Sport '{sport}' not supported")
+        needed = self.SPORT_SLOTS[sport]
+        queue = self.queues[sport]
+
+        selected: List[Group] = []
+        total_players = 0
+        for group in list(queue):
+            if total_players + group.size > needed:
+                continue
+            if ranked and selected:
+                if not self._within_mmr_threshold(selected, group, mmr_threshold):
+                    continue
+            selected.append(group)
+            total_players += group.size
+            if total_players == needed:
+                break
+
+        if total_players == needed:
+            for g in selected:
+                queue.remove(g)
+            return selected
+        return None
+
+    def _within_mmr_threshold(
+        self, groups: List[Group], new_group: Group, threshold: int
+    ) -> bool:
+        """Return True if ``new_group`` fits with ``groups`` by MMR."""
+        current_total_mmr = sum(g.avg_mmr * g.size for g in groups)
+        current_total_players = sum(g.size for g in groups)
+        new_avg = (
+            current_total_mmr + new_group.avg_mmr * new_group.size
+        ) / (current_total_players + new_group.size)
+        return all(
+            abs(g.avg_mmr - new_avg) <= threshold for g in groups + [new_group]
+        )
+
+if __name__ == "__main__":
+    qm = QueueManager()
+    # Example usage
+    team1 = Group([Player('a1', 1000), Player('a2', 1050), Player('a3', 990)])
+    team2 = Group([Player('b1', 1010), Player('b2', 995)])
+    team3 = Group([Player('c1', 1020), Player('c2', 1005), Player('c3', 1000), Player('c4', 980), Player('c5', 1015)])
+
+    qm.add_group('futebol', team1)
+    qm.add_group('futebol', team2)
+    qm.add_group('futebol', team3)
+
+    match = qm.match_groups('futebol', ranked=True)
+    print('Match:', match)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,54 @@
+import unittest
+from sports_queue import Player, Group, QueueManager
+
+class QueueManagerTests(unittest.TestCase):
+    def test_ranked_match(self):
+        qm = QueueManager()
+        g1 = Group([Player('a', 1000), Player('b', 1010)])
+        g2 = Group([Player('c', 1005), Player('d', 1005)])
+        g3 = Group([Player('e', 1000), Player('f', 990), Player('g', 995)])
+        g4 = Group([Player('h', 1005), Player('i', 1000), Player('j', 1005)])
+        qm.add_group('futebol', g1)
+        qm.add_group('futebol', g2)
+        qm.add_group('futebol', g3)
+        qm.add_group('futebol', g4)
+        match = qm.match_groups('futebol', ranked=True)
+        self.assertIsNotNone(match)
+        self.assertEqual(sum(g.size for g in match), 10)
+
+    def test_not_enough_players(self):
+        qm = QueueManager()
+        g1 = Group([Player('a', 1000)])
+        g2 = Group([Player('b', 1000)])
+        qm.add_group('basquete', g1)
+        qm.add_group('basquete', g2)
+        match = qm.match_groups('basquete', ranked=True)
+        self.assertIsNone(match)
+
+    def test_unranked_ignores_mmr(self):
+        qm = QueueManager()
+        g1 = Group([Player('a', 1000), Player('b', 1000), Player('c', 1000), Player('d', 1000), Player('e', 1000)])
+        g2 = Group([Player('f', 1500), Player('g', 1500), Player('h', 1500), Player('i', 1500), Player('j', 1500)])
+        qm.add_group('futebol', g1)
+        qm.add_group('futebol', g2)
+        match = qm.match_groups('futebol', ranked=False)
+        self.assertIsNotNone(match)
+        self.assertEqual(sum(g.size for g in match), 10)
+
+    def test_group_with_dummies(self):
+        qm = QueueManager()
+        group = Group([
+            Player('p1', 1000),
+            Player('dummy1', 1000, True),
+            Player('dummy2', 1000, True),
+            Player('dummy3', 1000, True),
+            Player('dummy4', 1000, True),
+        ])
+        qm.add_group('basquete', group)
+        qm.add_group('basquete', group)
+        match = qm.match_groups('basquete', ranked=True)
+        self.assertIsNotNone(match)
+        self.assertEqual(sum(g.size for g in match), 10)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,66 @@
+import unittest
+import threading
+import json
+from http.client import HTTPConnection
+from server import create_server, queue_manager
+
+class ServerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = create_server(port=0)
+        cls.port = cls.server.server_port
+        cls.thread = threading.Thread(target=cls.server.serve_forever)
+        cls.thread.daemon = True
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join()
+
+    def request(self, path, body):
+        conn = HTTPConnection('localhost', self.port)
+        conn.request('POST', path, body=json.dumps(body), headers={'Content-Type': 'application/json'})
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        return resp.status, json.loads(data.decode())
+
+    def test_add_and_match(self):
+        players = [{'id': 'p1', 'mmr': 1000}, {'id': 'p2', 'mmr': 1000}]
+        for _ in range(5):
+            status, _ = self.request('/add_group', {'sport': 'futebol', 'players': players})
+            self.assertEqual(status, 200)
+        status, data = self.request('/match', {'sport': 'futebol', 'ranked': True})
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(data['match'])
+        self.assertEqual(len(data['match']), 5)
+        self.assertEqual(sum(len(g) for g in data['match']), 10)
+
+    def test_unranked_endpoint(self):
+        g1 = [{'id': 'p1', 'mmr': 1000}] * 5
+        g2 = [{'id': 'p2', 'mmr': 1500}] * 5
+        self.request('/add_group', {'sport': 'futebol', 'players': g1})
+        self.request('/add_group', {'sport': 'futebol', 'players': g2})
+        status, data = self.request('/match', {'sport': 'futebol', 'ranked': False})
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(data['match'])
+        self.assertEqual(sum(len(g) for g in data['match']), 10)
+
+    def test_add_dummy_player(self):
+        group = [
+            {'id': 'p1', 'mmr': 1000},
+            {'id': 'p2', 'mmr': 1000},
+            {'id': 'dummy1', 'mmr': 1000, 'is_dummy': True},
+            {'id': 'dummy2', 'mmr': 1000, 'is_dummy': True},
+            {'id': 'dummy3', 'mmr': 1000, 'is_dummy': True},
+        ]
+        self.request('/add_group', {'sport': 'futebol', 'players': group})
+        self.request('/add_group', {'sport': 'futebol', 'players': group})
+        status, data = self.request('/match', {'sport': 'futebol', 'ranked': True})
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(data['match'])
+        self.assertEqual(sum(len(g) for g in data['match']), 10)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update README instructions for single search button
- update mobile README to reflect the single **Buscar partida** button
- simplify React Native app so "Buscar partida" both joins queue and searches for a match

## Testing
- `python -m unittest discover tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684b64c45c24832ca54edb58cd0f0f73